### PR TITLE
Add `watch_errors` option to the breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ See [Martin Fowler's article on the Circuit Breaker pattern for more info](http:
       def initialize
         @circuit_breaker = AllMyCircuits::Breaker.new(
           name: "my_service",
+          watch_errors: [Timeout::Error],               # defaults to AllMyCircuits::Breaker.net_errors,
+                                                        #   which includes typical net/http and socket errors
           sleep_seconds: 10,                            # leave circuit open for 10 seconds, than try to call the service again
           strategy: AllMyCircuits::Strategies::PercentageOverWindowStrategy.new(
             requests_window: 100,                       # number of requests to calculate the average failure rate for
@@ -67,5 +69,4 @@ This app allows to catch incorrect circuit breaker behavior visually.
 # TODO
 
   * global controls through redis?
-  * look for specific exceptions
 

--- a/script/graphing_stress_test.rb
+++ b/script/graphing_stress_test.rb
@@ -15,7 +15,7 @@ def setup
   @responses_queue = Queue.new
   @breaker = AllMyCircuits::Breaker.new(
     name: "test service circuit breaker",
-    sleep_seconds: 10,
+    sleep_seconds: 5,
     strategy: AllMyCircuits::Strategies::PercentageOverWindowStrategy.new(
       requests_window: 40,
       failure_rate_percent_threshold: 25

--- a/test/test_all_my_circuits.rb
+++ b/test/test_all_my_circuits.rb
@@ -10,6 +10,7 @@ class TestAllMyCircuits < AllMyCircuitsTC
     @fake_clock = FakeClock.new
     @breaker = AllMyCircuits::Breaker.new(
       name: "test service circuit breaker",
+      watch_errors: [SimulatedFailure],
       sleep_seconds: 4,
       clock: @fake_clock,
       strategy: AllMyCircuits::Strategies::PercentageOverWindowStrategy.new(

--- a/test/test_all_my_circuits_across_multiple_threads.rb
+++ b/test/test_all_my_circuits_across_multiple_threads.rb
@@ -12,6 +12,7 @@ class TestAllMyCircuitsAcrossMultipleThreads < AllMyCircuitsTC
     @responses_queue = Queue.new
     @breaker = AllMyCircuits::Breaker.new(
       name: "test service circuit breaker",
+      watch_errors: [SimulatedFailure],
       sleep_seconds: 2,
       strategy: AllMyCircuits::Strategies::NumberOverWindowStrategy.new(
         requests_window: 10,


### PR DESCRIPTION
... to prevent it from tripping the circuit open due to irrelevant issues.

I've tried to default to typical net/http errors, but this does not cover Faraday.
Will be rebased when #1 is merged.
